### PR TITLE
docs: document GitOps-based rollback procedure

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,7 +52,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: container-health:ci
-          severity: CRITICAL, HIGH
+          severity: CRITICAL,HIGH
           exit-code: 1
 
       - name: Validate /health endpoint

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,6 +15,11 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
+
+concurrency:
+  group: ci-cd-container-health
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -40,6 +45,15 @@ jobs:
           docker run --rm -d -p 8000:8000 --name container-health-ci container-health:ci
           sleep 5
 
+# Security scan with Trivy
+      - name: Trivy Security Scan
+        env:
+          TRIVY_CACHE_DIR: /tmp/.trivycache
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: container-health:ci
+          severity: CRITICAL, HIGH
+          exit-code: 1
 
       - name: Validate /health endpoint
         run: |
@@ -72,7 +86,8 @@ jobs:
 # SemVer PATCH versioning (Calcula la siguiente version de parche de la imagen para evitar usar 'latest' y asi evitar sobrescribir accidentalmente las versiones estables con algo no probado)
       - name: Calculate next version (SemVer PATCH)
         run: |
-          OLD=$(cat VERSION)
+          test -f VERSION || echo "0.1.0" > VERSION
+          OLD=$(cat VERSION)        
           IFS='.' read -r M m p <<< "$OLD"
           NEW="$M.$m.$((p+1))"
           echo "$NEW" > VERSION

--- a/docs/ci-cd-review.md
+++ b/docs/ci-cd-review.md
@@ -1,0 +1,26 @@
+# CI/CD Technical Review – aks-app-platform
+
+## Context
+This document captures a technical review of the current CI/CD implementation,
+focused on security, reliability, and maintainability.
+
+## What works well
+- Clear separation between CI and manual release
+- Security scanning with Trivy enforcing HIGH/CRITICAL gates
+- Semantic versioning with immutable image tags
+- GitOps-based deployment model
+
+## Identified risks / improvement areas
+- No rollback strategy defined in case of failed deployment
+- No visibility into deployment status post-merge
+- No environment separation (dev/stage/prod)
+
+## Suggested next steps
+- Introduce controlled rollback mechanism in GitOps repo
+- Add environment-based promotion strategy
+- Improve observability around deployments
+
+## Non-goals
+- No changes to application code
+- No migration to new CI/CD tooling
+- No changes to deployment strategy at this stage

--- a/docs/rollback.md
+++ b/docs/rollback.md
@@ -1,0 +1,42 @@
+# Rollback Procedure
+
+## Context
+This repository follows a GitOps deployment model where Git is the single source
+of truth for the desired state of the cluster.
+
+Application deployments are driven by image version updates committed to this
+repository and reconciled automatically by the GitOps controller.
+
+## Rollback strategy
+Rollback is performed by reverting the Git commit that introduced the faulty
+image version.
+
+No direct changes are applied to the cluster.
+
+## Rollback steps
+1. Identify the commit that updated the application image to the faulty version.
+2. Revert the commit:
+   ```bash
+   git revert <commit-sha>
+   git push
+   ```
+3. The GitOps controller detects the change and reconciles the cluster back to
+the previous stable version.
+
+Benefits
+
+- Full auditability through Git history
+
+- Deterministic and reproducible rollbacks
+
+- No manual intervention on the cluster
+
+- Consistent with GitOps principles
+
+## Non-goals
+
+- Automatic rollbacks based on health checks
+
+- Imperative rollback commands (kubectl rollout undo)
+
+- Out-of-band cluster changes


### PR DESCRIPTION
This PR documents the rollback strategy used for GitOps-managed deployments.

The procedure relies on reverting the Git commit that introduced a faulty image
version, ensuring auditability and keeping Git as the single source of truth.
