### PR TITLE
test: simulate CI failure to validate branch governance

### DIFF
--- a/.github/workflows/ci-failure-scenario.yml
+++ b/.github/workflows/ci-failure-scenario.yml
@@ -1,0 +1,17 @@
+name: CI Failure Scenario
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  quality-gate:
+    name: Quality Gate (Intentional Failure)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Simulate policy validation
+        run: |
+          echo "Validating platform policies"
+          echo "Policy violation detected!"
+          exit 1

--- a/.github/workflows/ci-failure-scenario.yml
+++ b/.github/workflows/ci-failure-scenario.yml
@@ -15,3 +15,4 @@ jobs:
           echo "Validating platform policies"
           echo "Policy violation detected!"
           exit 1
+          


### PR DESCRIPTION
## Purpose
Simulate a controlled CI failure to validate branch protection and governance enforcement.

## Expected behavior
- CI job fails
- Merge is blocked by required status checks

## Why this matters
Ensures non-compliant changes cannot reach main, even with PR approval.
