### PR TITLE
feat: integrate Prometheus observability for container-health

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.115.5
 uvicorn==0.29.0
 psutil==5.9.8
 jinja2==3.1.4
+prometheus-client==0.20.0

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -1,21 +1,35 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+from pathlib import Path
+from prometheus_client import Counter, generate_latest
+
+
+REQUEST_COUNT = Counter(
+    "http_requests_total",
+    "Total HTTP requests",
+    ["endpoint"]
+)
+
+BASE_DIR = Path(__file__).resolve().parent
+TEMPLATES_DIR = BASE_DIR.parent / "templates"
 
 import psutil
 import time
 
 app = FastAPI(title="Container Health Dashboard")
 
-templates = Jinja2Templates(directory="templates")
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 start_time = time.time()
 
 @app.get("/health")
 def healthcheck():
+    REQUEST_COUNT.labels(endpoint="/health").inc()
     return {"status": "ok"}
 @app.get("/", response_class=HTMLResponse)
 def dashboard(request: Request):
+    REQUEST_COUNT.labels(endpoint="/").inc()
     cpu_usage = psutil.cpu_percent(interval=0.1)
     memory_info = psutil.virtual_memory()
     memory_usage_mb = round(memory_info.used / (1024 * 1024), 2)
@@ -31,4 +45,11 @@ def dashboard(request: Request):
             "memory": memory_usage_mb,
             "uptime": uptime,
         }
+    )
+
+@app.get("/metrics")
+def metrics():
+    return Response(
+        generate_latest(),
+        media_type="text/plain; version=0.0.4; charset=utf-8"
     )

--- a/platform/apps/container-health/base/service.yaml
+++ b/platform/apps/container-health/base/service.yaml
@@ -2,11 +2,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: container-health
-  namespace: container-health
+  labels:
+    app: container-health
 spec:
   selector:
     app: container-health
   ports:
-    - port: 80
+    - name: http
+      protocol: TCP
+      port: 80
       targetPort: 8000
   type: ClusterIP

--- a/platform/monitoring/base/kustomization.yaml
+++ b/platform/monitoring/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - servicemonitor-container-health.yaml

--- a/platform/monitoring/base/servicemonitor-container-health.yaml
+++ b/platform/monitoring/base/servicemonitor-container-health.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: container-health
+  namespace: monitoring
+  labels:
+    release: monitoring
+
+spec:
+  selector:
+    matchLabels:
+      app: container-health
+  namespaceSelector:
+    matchNames:
+      - container-health-dev
+      - container-health-stage
+      - container-health-prod
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 15s

--- a/platform/monitoring/dev/kustomization.yaml
+++ b/platform/monitoring/dev/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base

--- a/platform/monitoring/prod/kustomization.yaml
+++ b/platform/monitoring/prod/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base

--- a/platform/monitoring/stage/kustomization.yaml
+++ b/platform/monitoring/stage/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base


### PR DESCRIPTION
## What was added
- Application-level Prometheus metrics (`http_requests_total`)
- `/metrics` endpoint exposed by the container-health app
- ServiceMonitor integrated with kube-prometheus-stack
- Observability aligned with existing Kustomize structure

## Why
This enables real observability of application traffic and validates the end-to-end Prometheus + Kubernetes integration, following platform best practices.

## Validation
- Prometheus target is UP
- Metrics are scraped successfully
- `http_requests_total` visible in Prometheus queries
