### PR TITLE
Chore/ci dev promotion guardrail

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,8 +3,12 @@ name: CI-CD - Container Health Platform
 on:
   push:
     branches: ["main"]
+    paths:
+      - 'app/**'
   pull_request:
     branches: ["main"]
+    paths:
+      - 'app/**'
   workflow_dispatch:
     inputs:
       environment:
@@ -26,7 +30,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ci-cd-container-health
+  group: ${{ github.workflow }}-${{ github.event_name }}
   cancel-in-progress: true
 
 env:
@@ -43,7 +47,6 @@ jobs:
         run: echo "ok"
 
   build:
-    if: github.event_name != 'workflow_dispatch'
     name: Build, scan and push image
     runs-on: ubuntu-latest
     needs: ci
@@ -59,6 +62,7 @@ jobs:
 
       - name: Build image
         run: |
+          echo "Building image because app code changed"
           docker build \
             -t $IMAGE_NAME:sha-${{ github.sha }} \
             ./app
@@ -77,7 +81,6 @@ jobs:
   release:
     name: Promote image via PR
     runs-on: ubuntu-latest
-    needs: ci
     if: github.event_name == 'workflow_dispatch'
     environment: ${{ inputs.environment }}
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -99,17 +99,19 @@ jobs:
           echo "Target environment: $ENV"
           echo "Image tag: $TAG"
 
-          if [ "$ENV" == "dev"]; then
-            echo "Promoting to dev; no prior validation required"
-            exit 0 # OK
-          fi
+          case "$ENV" in
+            dev)
+              echo "Promoting to dev; no prior validation needed."
+              exit 0 # OK
+              ;;
+          esac
 
           if [ ! -f "$DEV_TAG_FILE" ]; then
             echo "ERROR: Dev image-tag file not found. Cannot promote to $ENV"
             exit 1 # ERROR
           fi
 
-          DEV_TAG=$(cat "$DEV_TAG_FILE" | tr -d '\n')
+          DEV_TAG="$(cat "$DEV_TAG_FILE" | tr -d '[:space:]')"
 
           if [ "$DEV_TAG" != "$TAG" ]; then
             echo "ERROR: Image '$TAG' has not been promoted to dev."

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -95,19 +95,19 @@ jobs:
           TAG="${{ inputs.image_tag }}"
           DEV_TAG_FILE="platform/apps/container-health/dev/image-tag.txt"
 
-          if [[ "$ENV" == "dev"]]; then
+          if [ "$ENV" == "dev"]; then
             echo "Promoting to dev; no prior validation required"
             exit 0 # OK
           fi
 
-          if [[ ! -f "$DEV_TAG_FILE" ]]; then
+          if [ ! -f "$DEV_TAG_FILE" ]; then
             echo "ERROR: Dev image-tag file not found. Cannot promote to $ENV"
             exit 1 # ERROR
           fi
 
           DEV_TAG=$(cat "$DEV_TAG_FILE" | tr -d '\n')
 
-          if [[ "$DEV_TAG" != "$TAG" ]]; then
+          if [ "$DEV_TAG" != "$TAG" ]; then
             echo "ERROR: Image '$TAG' has not been promoted to dev."
             exit 1 # ERROR
           fi

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -95,6 +95,10 @@ jobs:
           TAG="${{ inputs.image_tag }}"
           DEV_TAG_FILE="platform/apps/container-health/dev/image-tag.txt"
 
+          echo "Validating promotion order..."
+          echo "Target environment: $ENV"
+          echo "Image tag: $TAG"
+
           if [ "$ENV" == "dev"]; then
             echo "Promoting to dev; no prior validation required"
             exit 0 # OK


### PR DESCRIPTION
## What does this PR do?

This change enforces a strict **build-once, promote-many** model for the Container Health Platform.

Container images are now built **only** when application code changes (`app/**`), using path-based triggers in the CI workflow.  
GitOps promotions (which only update image references and manifests) no longer trigger image rebuilds.

---

## Why is this needed?

Previously, promotion pull requests could still trigger the CI/CD pipeline, causing unnecessary image rebuilds even though no application code had changed.

This PR ensures:
- Immutable container images (tagged by commit SHA)
- Clear separation between CI (build & test) and CD (promotion)
- No rebuilds during environment promotions
- Cleaner, more predictable pipelines

---

## How it works

- CI and build jobs are triggered only when files under `app/**` change
- Promotion workflows update image-tag references via GitOps PRs
- Promotions never rebuild artifacts, they only move references across environments

---

## Impact

-  No behavior change for application development
-  Promotions are faster and safer
-  Aligns the pipeline with platform engineering best practices
