### PR TITLE
chore(ci): skip CI and build jobs during workflow_dispatch promotions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,6 +40,7 @@ jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch'
 
     steps:
       - uses: actions/checkout@v4
@@ -48,6 +49,7 @@ jobs:
 
   build:
     name: Build, scan and push image
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: ci
     steps:


### PR DESCRIPTION
## What does this PR do?

This PR fully decouples **CI/build** from **release promotions** when using `workflow_dispatch`.

CI and image build jobs are now explicitly skipped during manual promotion workflows, ensuring that promotions never trigger tests or image rebuilds.

---

## Why is this needed?

While path filters already prevented builds on manifest-only PRs and merges, `workflow_dispatch` triggers the entire workflow by default.

Without an explicit guard, this caused CI and build jobs to run during promotions, which breaks the **build-once, promote-many** model.

---

## How it works

- CI and build jobs are conditionally skipped when `github.event_name == 'workflow_dispatch'`
- Path-based triggers remain in place to ensure builds only happen when `app/**` changes
- Promotion workflows remain explicit, GitOps-based, and artifact-immutable

---

## Result

-  Builds run only on real application changes
-  Promotions never rebuild artifacts
-  Clear separation between CI and release responsibilities
-  Cleaner and more predictable pipelines aligned with platform engineering best practices
