### PR TITLE
feat(rollback): add automatic GitOps rollback for dev environment

### DIFF
--- a/.github/workflows/rollback-dev.yml
+++ b/.github/workflows/rollback-dev.yml
@@ -1,0 +1,78 @@
+name: Auto Rollback - Dev
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "platform/apps/container-health/dev/image-tag.txt"
+
+jobs:
+  rollback-dev:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Read new image tag
+        id: read_new
+        run: |
+          NEW_TAG=$(cat platform/apps/container-health/dev/image-tag.txt | tr -d '[:space:]')
+          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+
+      - name: Read previous image tag
+        id: read_prev
+        run: |
+          PREV_TAG=$(git show HEAD~1:platform/apps/container-health/dev/image-tag.txt | tr -d '[:space:]')
+          echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
+
+      - name: Check if rollback needed
+        id: check
+        run: |
+          echo "Checking rollout status for dev environment..."
+
+          # 🔴 Simulated rollout check (replace later with kubectl / ArgoCD)
+          DEPLOY_OK=false
+
+          if [ "$DEPLOY_OK" = true ]; then
+            echo "rollback=false" >> $GITHUB_OUTPUT
+            echo "Deployment healthy. No rollback needed."
+            exit 0
+          fi
+
+          echo "rollback=true" >> $GITHUB_OUTPUT
+          echo "Deployment unhealthy. Rollback required."
+
+      - name: Automatic Rollback
+        if: steps.check.outputs.rollback == 'true'
+        run: |
+          NEW_TAG="${{ steps.read_new.outputs.new_tag }}"
+          PREV_TAG="${{ steps.read_prev.outputs.prev_tag }}"
+
+          git checkout -b rollback-dev-$NEW_TAG
+
+          echo "$PREV_TAG" > platform/apps/container-health/dev/image-tag.txt
+
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+          git add platform/apps/container-health/dev/image-tag.txt
+          git commit -m "chore(rollback): revert container-health dev to $PREV_TAG"
+
+          git push origin rollback-dev-$NEW_TAG
+
+      - name: Create Rollback Pull Request
+        if: steps.check.outputs.rollback == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_TAG="${{ steps.read_new.outputs.new_tag }}"
+          PREV_TAG="${{ steps.read_prev.outputs.prev_tag }}"
+
+          gh pr create \
+            --base main \
+            --head rollback-dev-$NEW_TAG \
+            --title "chore(rollback): revert container-health dev to $PREV_TAG" \
+            --body "Automatic rollback to previously known-good image \`$PREV_TAG\` after failed dev deployment."


### PR DESCRIPTION
## What does this PR do?

This PR introduces an **automatic rollback mechanism for the dev environment**, fully aligned with our GitOps and build-once, promote-many model.

When a new image is promoted to **dev** and the deployment is detected as unhealthy, the system automatically reverts the image reference to the previously known-good version by creating a rollback Pull Request.

No images are rebuilt during this process.

---

## Why is this needed?

Even with safe CI and controlled promotions, deployments can still fail at runtime (misconfiguration, bad image, startup issues, etc.).

This change ensures that:
- Dev stays stable without manual intervention
- Failed deployments are reverted quickly
- Rollbacks are deterministic, auditable, and version-controlled
- Git remains the single source of truth

---

## How it works

- The workflow is triggered on changes to `platform/apps/container-health/dev/image-tag.txt`
- It reads the newly promoted image tag and the previous one from Git history
- A deployment health check is evaluated (simulated for now)
- If the deployment is unhealthy:
  - The image tag is reverted to the previous value
  - A rollback branch is created
  - A Pull Request is opened automatically against `main`

The rollback workflow:
- Does **not** rebuild images
- Does **not** run CI
- Only updates GitOps manifests

---

## Scope and safety

-  Applies only to the **dev** environment
-  Fully automated
-  GitOps-compliant
- Easy to extend to stage/prod with additional controls

This establishes a solid rollback foundation that can later be enhanced with real deployment checks (AKS / ArgoCD) and notifications.
